### PR TITLE
fixed id to use integer, uuid the worst for performance

### DIFF
--- a/moolah/models.py
+++ b/moolah/models.py
@@ -1,4 +1,4 @@
-from uuid import uuid4
+#from uuid import uuid4
 from datetime import timedelta, datetime
 
 from django.db import models
@@ -73,9 +73,8 @@ class TransactionBaseQuerySet(models.QuerySet):
 class TransactionBase(models.Model):
     objects = TransactionBaseQuerySet.as_manager()
 
-    id = models.UUIDField(primary_key=True,
+    id = models.IntegerField(primary_key=True,
                           editable=False,
-                          default=uuid4,
                           unique=True)
 
     description = models.CharField(max_length=120)


### PR DESCRIPTION
UUIDs should never be used for database keys, and they should not be the primary key on a field, unless you want to randomize the order of the rows on your database. 

see here: https://www.percona.com/blog/2007/03/13/to-uuid-or-not-to-uuid/
