### PR TITLE
Serve statics in develop mode and rearrange Bower 

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory" : "bower/bower_components"
+  "directory" : "static/vendors"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.pyc
 *.sqlite3
-bower
+
+static/vendors
 node_modules
-prod_static
+
+public/static
+public/media

--- a/bower.json
+++ b/bower.json
@@ -25,5 +25,8 @@
     "font-awesome": "~4.4.0",
     "angular-busy": "~4.1.3",
     "angular-chart.js": "~0.8.5"
+  },
+  "resolutions": {
+    "angular": "1.4.7"
   }
 }

--- a/moolah/settings.py
+++ b/moolah/settings.py
@@ -75,11 +75,15 @@ REST_FRAMEWORK = {
 }
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'prod_static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'public', 'static')
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'public', 'media')
+
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'bower'),
     os.path.join(BASE_DIR, 'static')
 ]
+
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',

--- a/moolah/urls.py
+++ b/moolah/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.conf import settings
 from django.views.generic import TemplateView
 from django.contrib.auth.decorators import login_required
 
@@ -14,3 +15,10 @@ urlpatterns = [
     url(r'^accounts/', include('django.contrib.auth.urls')),
     url(r'^$', login_required(TemplateView.as_view(template_name='index.html')))
 ]
+
+
+if settings.DEBUG:
+    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+    from django.conf.urls.static import static
+
+    urlpatterns += staticfiles_urlpatterns()

--- a/templates/css.html
+++ b/templates/css.html
@@ -1,9 +1,9 @@
 {% load staticfiles %}
-<link href="{% static 'bower_components/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet"/>
-<link href="{% static 'bower_components/bootstrap-material-design/dist/css/roboto.min.css' %}" rel="stylesheet">
-<link href="{% static 'bower_components/bootstrap-material-design/dist/css/material.min.css' %}" rel="stylesheet">
-<link href="{% static 'bower_components/bootstrap-material-design/dist/css/ripples.min.css' %}" rel="stylesheet">
-<link href="{% static 'bower_components/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet"/>
-<link href="{% static 'bower_components/angular-busy/dist/angular-busy.min.css' %}" rel="stylesheet"/>
-<link href="{% static 'bower_components/angular-chart.js/dist/angular-chart.min.css' %}" rel="stylesheet"/>
+<link href="{% static 'vendors/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet"/>
+<link href="{% static 'vendors/bootstrap-material-design/dist/css/roboto.min.css' %}" rel="stylesheet">
+<link href="{% static 'vendors/bootstrap-material-design/dist/css/material.min.css' %}" rel="stylesheet">
+<link href="{% static 'vendors/bootstrap-material-design/dist/css/ripples.min.css' %}" rel="stylesheet">
+<link href="{% static 'vendors/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet"/>
+<link href="{% static 'vendors/angular-busy/dist/angular-busy.min.css' %}" rel="stylesheet"/>
+<link href="{% static 'vendors/angular-chart.js/dist/angular-chart.min.css' %}" rel="stylesheet"/>
 <link href="{% static 'css/site.css' %}" rel="stylesheet">

--- a/templates/scripts.html
+++ b/templates/scripts.html
@@ -1,13 +1,13 @@
 {% load staticfiles %}
 <script src="{% static 'js/polyfills.js' %}"></script>
-<script src="{% static 'bower_components/jquery/dist/jquery.min.js' %}"></script>
-<script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}"></script>
-<script src="{% static 'bower_components/angular/angular.js' %}"></script>
-<script src="{% static 'bower_components/angular-route/angular-route.min.js' %}"></script>
-<script src="{% static 'bower_components/angular-resource/angular-resource.min.js' %}"></script>
-<script src="{% static 'bower_components/moment/moment.js' %}"></script>
-<script src="{% static 'bower_components/bootstrap-material-design/dist/js/ripples.min.js' %}"></script>
-<script src="{% static 'bower_components/bootstrap-material-design/dist/js/material.min.js' %}"></script>
-<script src="{% static 'bower_components/angular-busy/dist/angular-busy.min.js' %}"></script>
-<script src="{% static 'bower_components/Chart.js/Chart.min.js' %}"></script>
-<script src="{% static 'bower_components/angular-chart.js/dist/angular-chart.min.js' %}"></script>
+<script src="{% static 'vendors/jquery/dist/jquery.min.js' %}"></script>
+<script src="{% static 'vendors/bootstrap/dist/js/bootstrap.min.js' %}"></script>
+<script src="{% static 'vendors/angular/angular.js' %}"></script>
+<script src="{% static 'vendors/angular-route/angular-route.min.js' %}"></script>
+<script src="{% static 'vendors/angular-resource/angular-resource.min.js' %}"></script>
+<script src="{% static 'vendors/moment/moment.js' %}"></script>
+<script src="{% static 'vendors/bootstrap-material-design/dist/js/ripples.min.js' %}"></script>
+<script src="{% static 'vendors/bootstrap-material-design/dist/js/material.min.js' %}"></script>
+<script src="{% static 'vendors/angular-busy/dist/angular-busy.min.js' %}"></script>
+<script src="{% static 'vendors/Chart.js/Chart.min.js' %}"></script>
+<script src="{% static 'vendors/angular-chart.js/dist/angular-chart.min.js' %}"></script>


### PR DESCRIPTION
Hello Alex,

Glad to had found this project!, I made the following changes to make sure it will work faster to developers to start looking around.
1. Added the /static/ and /media/ serving in the urls, just in debug mode
2. Move static and media, to a /public directory this is a common practice that helps to better serve assets in production, like for example in nginx set the root for that directory and directly serve it without doing aliases or symlinks.
3. Bower components are stored in the static folder (not the public/static) that way when collecting statics it is also copied, this is useful if you have an IDE that looks for path resolution in your js or css code.
4. Bower configuration needs a resolution suggestion for the angular version, I added.

Now, after checkout, you just need to do `make` `python manage.py runserver` works like a charm.

Congrats for the project!
